### PR TITLE
opentelemetry-instrumentation-google-generativeai 0.49.6 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-google-generativeai" %}
-{% set version = "0.47.2" %}
+{% set version = "0.49.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 8c91526374a0fb81d02c4215eb5f1ee339807797c37e129a792377c9419288f1
+  sha256: dd3ff86d79bd13cad9e28658eddbd37cbf71c62e997e3de385093508a9b06dea
 
 build:
   number: 0
@@ -21,9 +21,9 @@ requirements:
     - poetry-core
   run:
     - python
-    - opentelemetry-api >=1.28.0,<2.0.0
-    - opentelemetry-instrumentation >=0.50b0
-    - opentelemetry-semantic-conventions >=0.50b0
+    - opentelemetry-api >=1.38.0,<2.0.0
+    - opentelemetry-instrumentation >=0.59b0
+    - opentelemetry-semantic-conventions >=0.59b0
     - opentelemetry-semantic-conventions-ai >=0.4.13,<0.5
   run_constrained:
     - google-genai >=1,<2


### PR DESCRIPTION
opentelemetry-instrumentation-google-generativeai 0.49.6 

**Destination channel:** Defaults

### Links

- [PKG-11114]
- dev_url:        https://github.com/traceloop/openllmetry/tree/0.49.6
- conda_forge:    https://github.com/conda-forge/opentelemetry-instrumentation-google-generativeai-feedstock
- pypi:           https://pypi.org/project/opentelemetry-instrumentation-google-generativeai/0.49.6
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-instrumentation-google-generativeai/0.49.6

### Explanation of changes:

- new version number


[PKG-11114]: https://anaconda.atlassian.net/browse/PKG-11114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ